### PR TITLE
Rename _rm function, it was interfering with oh-my-zsh tab completion

### DIFF
--- a/script.zsh
+++ b/script.zsh
@@ -33,7 +33,7 @@ function _encrypt {
     rm $file
 }
 
-function _rm {
+function _remove_file {
     rm $SECRET_FILENAME
 }
 
@@ -48,7 +48,7 @@ case $1 in
         _encrypt
         ;;
     rm)
-        _rm
+        _remove_file
         ;;
     *)
         echo "Unknown subcommand $1. source, decrypt or encrypt must be used"
@@ -57,6 +57,6 @@ esac
 
 unfunction _decrypt
 unfunction _source_secrets
-unfunction _rm
+unfunction _remove_file
 unfunction decrypt_to_out
 unfunction realpath


### PR DESCRIPTION
Not entirely sure what the cause of the issue is but if `secrets` is invoked then I try to use tab completion with `rm` I get an error. Renaming `_rm` resolved this issue. Gif belows show me invoking `secrets` then typing `rm an[TAB]` and the error I get.

![zsh-secrets-rm](https://user-images.githubusercontent.com/12345/147978799-7418f53a-f16d-4270-8d33-eb80b6640b51.gif)
