### PR TITLE
Only remove unencrypted file if encryption is successful

### DIFF
--- a/script.zsh
+++ b/script.zsh
@@ -28,9 +28,12 @@ function _decrypt {
 function _encrypt {
     echo "Encrypting $SECRET_NAME as $SECRET_FILENAME"
     local file=$(realpath $FILE_NAME)
-    gpg --batch --yes --output $SECRET_FILENAME --encrypt --recipient $RECEPIENT $file
-    echo "Removing $file"
-    rm $file
+    if gpg --batch --yes --output $SECRET_FILENAME --encrypt --recipient $RECEPIENT $file ; then
+      echo "Removing $file"
+      rm $file
+    else
+      echo "Failed to encrypt $file"
+    fi
 }
 
 function _rm {


### PR DESCRIPTION
Only remove temporary secrets file if encryption was successful otherwise show a warning. Useful if you've misconfigured the RECEPIENT or something else and you want to try again but have no other copy of the secret your trying to encrypt.